### PR TITLE
Upgrade google repo

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,10 +6,10 @@ import (
 	"io/ioutil"
 	"strconv"
 
-	bigquery "code.google.com/p/google-api-go-client/bigquery/v2"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
+	bigquery "google.golang.org/api/bigquery/v2"
 )
 
 type Client struct {


### PR DESCRIPTION
Hi, there :sunny: 

`code.google.com/p/google-api-go-client` has moved to github.
See here : https://code.google.com/p/google-api-go-client/

Warinig message is below.

``` bash
$ go get -u -f github.com/gotokatsuya/bigquery
warning: code.google.com is shutting down; import path code.google.com/p/google-api-go-client/bigquery/v2 will stop working
warning: code.google.com is shutting down; import path code.google.com/p/google-api-go-client/googleapi will stop working
warning: code.google.com is shutting down; import path code.google.com/p/google-api-go-client/googleapi/internal/uritemplates will stop working
```
### Usage

GitHub repo is [here](https://github.com/google/google-api-go-client), and use like this

``` go
import "google.golang.org/api/bigquery/v2"
```
